### PR TITLE
ISSUE-4-add-original-file-name-to-encrypted-message

### DIFF
--- a/src/main/kotlin/KotlinPGP.kt
+++ b/src/main/kotlin/KotlinPGP.kt
@@ -365,6 +365,7 @@ object KotlinPGP {
             armoredOutputStream.setHeader(head.key, head.value)
         }
         val messageBytes = encryptParameter.message.toByteArray()
+        val messageName = encryptParameter.messageOriginatingFileName.ifEmpty { PGPLiteralData.CONSOLE }
         val signatureGenerator: PGPSignatureGenerator?
         var signatureHashAlgorithm = 0
         if (encryptParameter.enableSignature) {
@@ -428,7 +429,7 @@ object KotlinPGP {
             val literalDataGeneratorOutput = literalDataGenerator.open(
                 bcpgOutputStream,
                 PGPLiteralData.UTF8,
-                PGPLiteralData.CONSOLE,
+                messageName,
                 Date(),
                 ByteArray(1 shl 16)
             )

--- a/src/main/kotlin/data/EncryptParameter.kt
+++ b/src/main/kotlin/data/EncryptParameter.kt
@@ -8,7 +8,8 @@ data class EncryptParameter(
     val enableSignature: Boolean = false,
     val privateKey: String = "",
     val password: String = "",
-    val compressionAlgorithm: Int = CompressionAlgorithmTags.ZIP
+    val compressionAlgorithm: Int = CompressionAlgorithmTags.ZIP,
+    val messageOriginatingFileName: String = ""
 )
 
 data class PublicKeyData(

--- a/src/test/kotlin/KotlinPGPTest.kt
+++ b/src/test/kotlin/KotlinPGPTest.kt
@@ -190,6 +190,16 @@ class KotlinPGPTest : FreeSpec({
                     it.isPGPMessage
                 }
             }
+            "encrypt data with originating filename" {
+                val encryptResult = KotlinPGP.encrypt(EncryptParameter(
+                    message = contentToEncrypt,
+                    publicKey = publicKeys,
+                    messageOriginatingFileName = "test"
+                ))
+                encryptResult should {
+                    it.isPGPMessage
+                }
+            }
             "decrypt" - {
                 val encryptedData = KotlinPGP.encrypt(EncryptParameter(
                     message = contentToEncrypt,


### PR DESCRIPTION
Include original filename for the message to be encrypted. By default, name is set and coming as 'CONSUL'